### PR TITLE
Update to new link format

### DIFF
--- a/GCImageGrabber.py
+++ b/GCImageGrabber.py
@@ -24,7 +24,7 @@ def getResponse(url):
 
     response = requests.get(url=url).text
 
-    start = response.find('https://assets.amuniversal.com')
+    start = response.find('https://featureassets.amuniversal.com/assets/')
     link = response[start:].partition('"')[0]
     print(f'Image URL for {url} is {link}')
 


### PR DESCRIPTION
As of today, the link format for all comics seems to have changed from `https://assets.amuniversal.com/` to `https://featureassets.amuniversal.com/assets/`. Changing this line fixes the download.